### PR TITLE
fix for dark mode ssr 'flash'.

### DIFF
--- a/app/hooks/useDarkMode.ts
+++ b/app/hooks/useDarkMode.ts
@@ -10,19 +10,19 @@ export default function useDarkMode() {
     ) as boolean
 
     // if there's no pref, set one up based on system pref
-    if (existingPreference === null) {
-      window.matchMedia('(prefers-color-scheme: dark)').matches
-        ? // user's system theme is dark
-          (() => {
-            setDark(true)
-            localStorage.setItem('useDarkMode', 'true')
-          })()
-        : // user's system theme is light
-          (() => {
-            setDark(false)
-            localStorage.setItem('useDarkMode', 'false')
-          })()
-    }
+    // if (existingPreference === null) {
+    //   window.matchMedia('(prefers-color-scheme: dark)').matches
+    //     ? // user's system theme is dark
+    //       (() => {
+    //         setDark(true)
+    //         localStorage.setItem('useDarkMode', 'true')
+    //       })()
+    //     : // user's system theme is light
+    //       (() => {
+    //         setDark(false)
+    //         localStorage.setItem('useDarkMode', 'false')
+    //       })()
+    // }
 
     // if pref exists already and we're still initializing (i.e. first run), enforce it now
     if (!initialized) {
@@ -33,7 +33,7 @@ export default function useDarkMode() {
     // set the updated choice of dark mode
     localStorage.setItem('useDarkMode', `${dark}`)
     const dataTheme = dark ? 'dark' : 'light'
-    document.documentElement.setAttribute('data-theme', dataTheme)
+    document.documentElement.setAttribute('data-reactroot', dataTheme)
   }, [dark])
 
   return { dark, setDark }

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -10,11 +10,12 @@ import {
   useCatch,
 } from 'remix'
 import type { LinksFunction } from 'remix'
+import setTheme from './utils/setTheme'
 import useDarkMode from '~/hooks/useDarkMode'
 import Switch, { links as switchLinks } from '~/components/Switch/Switch'
 
 import globalStylesUrl from '~/styles/global.css'
-import darkStylesUrl from '~/styles/dark.css'
+// import darkStylesUrl from '~/styles/dark.css'
 
 // https://remix.run/api/app#links
 export let links: LinksFunction = () => {
@@ -115,6 +116,7 @@ function Document({
         <Links />
       </head>
       <body>
+        <div title="setTheme script" dangerouslySetInnerHTML={setTheme()} />
         {children}
         <ScrollRestoration />
         <Scripts />

--- a/app/styles/global.css
+++ b/app/styles/global.css
@@ -131,7 +131,8 @@
 }
 
 /* Dark Theme */
-[data-theme='dark'] {
+/* this data-reactroot attribute is ridiculous */
+[data-reactroot='dark'] {
   --color-foreground: hsl(0, 0%, 100%);
   --color-background: hsl(210deg, 30%, 8%);
   --color-links: hsl(213, 100%, 73%);

--- a/app/utils/setTheme.ts
+++ b/app/utils/setTheme.ts
@@ -1,0 +1,31 @@
+export default function setTheme() {
+  return {
+    __html: `<script>
+      let dark = null
+      const existingPreference = JSON.parse(localStorage.getItem('useDarkMode'))
+
+      // if there's no pref, set one up based on system pref
+      if (existingPreference === null) {
+        window.matchMedia('(prefers-color-scheme: dark)').matches
+          ?
+            (() => {
+              dark = true;
+              localStorage.setItem('useDarkMode', 'true')
+            })()
+          :
+            (() => {
+              dark = false;
+              localStorage.setItem('useDarkMode', 'false')
+            })()
+      }
+      else {
+        existingPreference ? dark = true : dark = false;
+      }
+
+      // set the updated choice of dark mode
+      localStorage.setItem('useDarkMode', dark.toString())
+      const dataTheme = dark ? 'dark' : 'light'
+      document.documentElement.setAttribute('data-reactroot', dataTheme)
+    </script>`,
+  }
+}


### PR DESCRIPTION
not a fan of the fix but it at least makes sense. However, the requirement for a specific attribute name from react to avoid a console error (warning) seems silly to me. After inspecting the source code it's frankly strange to me that the escape hatch isn't based on a prefix...